### PR TITLE
Refactor component framework to enable dynamic polymorphism

### DIFF
--- a/include/components/shared-component.hpp
+++ b/include/components/shared-component.hpp
@@ -2,8 +2,6 @@
 #define SHARED_COMPONENT_HPP_INCLUDED
 
 #include "systems/rewindable-map.hpp"
-#include "component.hpp"
-#include "component-container.hpp"
 
 namespace trillek { namespace component {
 
@@ -25,80 +23,71 @@ public:
 template<Component C>
 RewindableMap<id_t, bool,frame_tp,30> SharedContainer<C,bool>::container;
 
-class Shared final {
+template<Component C>
+class Shared final : public ContainerBase {
 public:
     Shared() {};
     ~Shared() {};
 
-    template<Component type>
-    const typename type_trait<type>::value_type& Get(id_t entity_id) {
-        return *component::Get<type>(Map<type>().Map().at(entity_id));
+    const typename type_trait<C>::value_type& Get(id_t entity_id) {
+        return *component::Get<C>(Map().Map().at(entity_id));
     }
 
-    template<Component type>
     std::shared_ptr<const Container> GetConstContainer(id_t entity_id) {
-        return Map<type>().Map().at(entity_id);
+        return Map().Map().at(entity_id);
     }
 
-    template<Component type>
-    std::shared_ptr<const typename type_trait<type>::value_type> GetSharedPtr(id_t entity_id) {
-        const auto& ptr = std::const_pointer_cast<Container>(Map<type>().Map().at(entity_id));
-        return component::Get<type,const typename type_trait<type>::value_type>(ptr);
+    std::shared_ptr<const typename type_trait<C>::value_type> GetSharedPtr(id_t entity_id) {
+        const auto& ptr = std::const_pointer_cast<Container>(Map().Map().at(entity_id));
+        return component::Get<C,const typename type_trait<C>::value_type>(ptr);
     }
 
-    template<Component type>
     bool Has(id_t entity_id) {
-        return Map<type>().Map().count(entity_id);
+        return Map().Map().count(entity_id);
     }
 
-    template<Component type, class V>
+    template<class V>
     void Insert(id_t entity_id, V&& value, typename std::enable_if<!util::is_shared_ptr<typename std::decay<V>::type>::value>::type* = 0) {
-        Map<type>().Insert(entity_id, component::CreateConst<type>(std::forward<V>(value)));
+        Map().Insert(entity_id, component::CreateConst<C>(std::forward<V>(value)));
     }
 
 
-    template<Component type, class V>
+    template<class V>
     void Insert(id_t entity_id, V&& value, typename std::enable_if<util::is_shared_ptr<typename std::decay<V>::type>::value>::type* = 0) {
-        Map<type>().Insert(entity_id, std::forward<V>(value));
+        Map().Insert(entity_id, std::forward<V>(value));
     }
 
-    template<Component type, class V>
+    template<class V>
     void Update(id_t entity_id, V&& value, typename std::enable_if<!util::is_shared_ptr<typename std::decay<V>::type>::value>::type* = 0) {
-        Map<type>().Update(entity_id, component::CreateConst<type>(std::forward<V>(value)));
+        Map().Update(entity_id, component::CreateConst<C>(std::forward<V>(value)));
     }
 
-    template<Component type, class V>
+    template<class V>
     void Update(id_t entity_id, V&& value, typename std::enable_if<util::is_shared_ptr<typename std::decay<V>::type>::value>::type* = 0) {
-        Map<type>().Update(entity_id, std::forward<V>(value));
+        Map().Update(entity_id, std::forward<V>(value));
     }
 
-    template<Component type>
     void Remove(id_t entity_id) {
-        Map<type>().Remove(entity_id);
+        Map().Remove(entity_id);
     }
 
 
-    template<Component C>
     void Commit(frame_tp frame) {
-        Map<C>().Commit(frame);
+        Map().Commit(frame);
     }
 
-    template<Component C>
     const SharedContainerConst<id_t,typename type_trait<C>::value_type>& GetLastPositiveCommit() {
-        return Map<C>().GetLastPositiveCommit();
+        return Map().GetLastPositiveCommit();
     }
 
-    template<Component C>
     const BitMap<uint32_t>& GetLastPositiveBitMap() {
-        return Map<C>().GetLastPositiveBitMap();
+        return Map().GetLastPositiveBitMap();
     }
 
-    template<Component C>
     const BitMap<uint32_t>& Bitmap() {
-        return Map<C>().Bitmap();
+        return Map().Bitmap();
     }
 
-    template<Component C>
     RewindableMap<id_t, std::shared_ptr<const Container>,frame_tp,30>& Map() {
         return SharedContainer<C,typename type_trait<C>::value_type>::container;
     }

--- a/include/components/system-component-value.hpp
+++ b/include/components/system-component-value.hpp
@@ -2,12 +2,11 @@
 #define SYSTEM_COMPONENT_VALUE_HPP_INCLUDED
 
 #include <map>
-#include "component.hpp"
 #include "bitmap.hpp"
 
 namespace trillek { namespace component {
 
-template<Component type,class T>
+template<Component C,class T>
 class SystemValueContainer {
 public:
     typedef std::map<id_t, T,std::less<id_t>,
@@ -38,62 +37,60 @@ typename SystemValueContainer<C,bool>::container_type SystemValueContainer<C,boo
 template<Component C>
 BitMap<uint32_t>& SystemValueContainer<C,bool>::bitmap = SystemValueContainer<C,bool>::container;
 
-class SystemValue final {
+template<Component C>
+class SystemValue final : public ContainerBase {
 public:
     SystemValue() {};
     ~SystemValue() {};
 
-    template<Component type>
-    typename type_trait<type>::value_type& Get(id_t entity_id, typename std::enable_if<!std::is_same<typename type_trait<type>::value_type,bool>::value>::type* = 0) {
-        return Map<type>().at(entity_id);
+    template<Component D=C>
+    typename type_trait<C>::value_type& Get(id_t entity_id, typename std::enable_if<!std::is_same<typename type_trait<D>::value_type,bool>::value>::type* = 0) {
+        return Map().at(entity_id);
     }
 
     // bool specialization
-    template<Component type>
-    typename type_trait<type>::value_type Get(id_t entity_id, typename std::enable_if<std::is_same<typename type_trait<type>::value_type,bool>::value>::type* = 0) {
-        return Map<type>().at(entity_id);
+    template<Component D=C>
+    typename type_trait<C>::value_type Get(id_t entity_id, typename std::enable_if<std::is_same<typename type_trait<D>::value_type,bool>::value>::type* = 0) {
+        return Map().at(entity_id);
     }
 
-    template<Component C>
     bool Has(id_t entity_id) {
-        return Bitmap<C>().at(entity_id);
+        return Bitmap().at(entity_id);
     }
 
-    template<Component C, class V>
-    void Insert(id_t entity_id, V&& value, typename std::enable_if<!std::is_same<typename type_trait<C>::value_type,bool>::value>::type* = 0) {
-        Update<C>(entity_id, std::forward<V>(value));
+    template<class V,Component D=C>
+    void Insert(id_t entity_id, V&& value, typename std::enable_if<!std::is_same<typename type_trait<D>::value_type,bool>::value>::type* = 0) {
+        Update(entity_id, std::forward<V>(value));
         SystemValueContainer<C,typename type_trait<C>::value_type>::bitmap[entity_id] = true;
     }
 
     // bool specialization
-    template<Component C, class V>
-    void Insert(id_t entity_id, V&& value, typename std::enable_if<std::is_same<typename type_trait<C>::value_type,bool>::value>::type* = 0) {
-        Update<C>(entity_id, std::forward<V>(value));
+    template<class V,Component D=C>
+    void Insert(id_t entity_id, V&& value, typename std::enable_if<std::is_same<typename type_trait<D>::value_type,bool>::value>::type* = 0) {
+        Update(entity_id, std::forward<V>(value));
     }
 
-    template<Component type, class V>
+    template<class V>
     void Update(id_t entity_id, V&& value) {
-        (Map<type>())[entity_id] = std::forward<V>(value);
+        (Map())[entity_id] = std::forward<V>(value);
     }
 
-    template<Component type>
-    void Remove(id_t entity_id, typename std::enable_if<!std::is_same<typename type_trait<type>::value_type,bool>::value>::type* = 0) {
-        Map<type>().erase(entity_id);
-        SystemValueContainer<type,typename type_trait<type>::value_type>::bitmap[entity_id] = false;
+    template<Component D=C>
+    void Remove(id_t entity_id, typename std::enable_if<!std::is_same<typename type_trait<D>::value_type,bool>::value>::type* = 0) {
+        Map().erase(entity_id);
+        SystemValueContainer<C,typename type_trait<C>::value_type>::bitmap[entity_id] = false;
     }
 
     // bool specialization
-    template<Component type>
-    void Remove(id_t entity_id, typename std::enable_if<std::is_same<typename type_trait<type>::value_type,bool>::value>::type* = 0) {
-        Map<type>().erase(entity_id);
+    template<Component D=C>
+    void Remove(id_t entity_id, typename std::enable_if<std::is_same<typename type_trait<D>::value_type,bool>::value>::type* = 0) {
+        Map().erase(entity_id);
     }
 
-    template<Component C>
     typename SystemValueContainer<C,typename type_trait<C>::value_type>::container_type& Map() {
         return SystemValueContainer<C,typename type_trait<C>::value_type>::container;
     }
 
-    template<Component C>
     const BitMap<uint32_t>& Bitmap() {
         return SystemValueContainer<C,typename type_trait<C>::value_type>::bitmap;
     }

--- a/include/components/system-component.hpp
+++ b/include/components/system-component.hpp
@@ -2,8 +2,6 @@
 #define SYSTEM_COMPONENT_HPP_INCLUDED
 
 #include <map>
-#include "component.hpp"
-#include "component-container.hpp"
 #include "bitmap.hpp"
 
 namespace trillek { namespace component {
@@ -24,56 +22,62 @@ typename SystemContainer<type>::container_type SystemContainer<type>::container;
 template<Component C>
 BitMap<uint32_t> SystemContainer<C>::bitmap;
 
-class System final {
+template<Component C>
+class System final : public ContainerBase {
 public:
     System() {};
     ~System() {};
 
-    template<Component type>
-    typename type_trait<type>::value_type& Get(id_t entity_id) {
-        return *component::Get<type>(Map<type>().at(entity_id));
+    typename type_trait<C>::value_type& Get(id_t entity_id) {
+        return *component::Get<C>(Map().at(entity_id));
     }
 
-    template<Component type>
     std::shared_ptr<Container> GetContainer(id_t entity_id) {
-        return Map<type>().Map().at(entity_id);
+        return Map().at(entity_id);
     }
 
-    template<Component type>
-    std::shared_ptr<typename type_trait<type>::value_type> GetSharedPtr(id_t entity_id) {
-        const auto& ptr = Map<type>().at(entity_id);
-        return component::Get<type>(ptr);
+    std::shared_ptr<typename type_trait<C>::value_type> GetSharedPtr(id_t entity_id) {
+        const auto& ptr = Map().at(entity_id);
+        return component::Get<C>(ptr);
     }
 
-    template<Component C>
     bool Has(id_t entity_id) {
-        return Bitmap<C>().at(entity_id);
+        return Bitmap().at(entity_id);
     }
 
-    template<Component type, class V>
-    void Insert(id_t entity_id, V&& value) {
-        Map<type>().insert(std::make_pair(std::move(entity_id), component::Create<type>(std::forward<V>(value))));
-        LOGMSG(DEBUG) << "system inserting component " << reflection::GetTypeName<std::integral_constant<Component,type>>() << " for entity #" << entity_id;
-        SystemContainer<type>::bitmap[entity_id] = true;
+    template<class V>
+    void Insert(id_t entity_id, V&& value, typename std::enable_if<!util::is_shared_ptr<typename std::decay<V>::type>::value>::type* = 0) {
+        Map().insert(std::make_pair(std::move(entity_id), component::Create<C>(std::forward<V>(value))));
+        LOGMSG(DEBUG) << "system inserting component " << reflection::GetTypeName<std::integral_constant<Component,C>>() << " for entity #" << entity_id;
+        SystemContainer<C>::bitmap[entity_id] = true;
     }
 
-    template<Component type, class V>
-    void Update(id_t entity_id, V&& value) {
-        Map<type>().at(entity_id) = component::Create<type>(std::forward<V>(value));
+    template<class V>
+    void Insert(id_t entity_id, V&& value, typename std::enable_if<util::is_shared_ptr<typename std::decay<V>::type>::value>::type* = 0) {
+        Map().insert(std::make_pair(std::move(entity_id), std::forward<V>(value)));
+        LOGMSG(DEBUG) << "system inserting component " << reflection::GetTypeName<std::integral_constant<Component,C>>() << " for entity #" << entity_id;
+        SystemContainer<C>::bitmap[entity_id] = true;
     }
 
-    template<Component type>
+    template<class V>
+    void Update(id_t entity_id, V&& value, typename std::enable_if<!util::is_shared_ptr<typename std::decay<V>::type>::value>::type* = 0) {
+        Map().at(entity_id) = component::Create<C>(std::forward<V>(value));
+    }
+
+    template<class V>
+    void Update(id_t entity_id, V&& value, typename std::enable_if<util::is_shared_ptr<typename std::decay<V>::type>::value>::type* = 0) {
+        Map().at(entity_id) = std::forward<V>(value);
+    }
+
     void Remove(id_t entity_id) {
-        Map<type>().erase(entity_id);
-        SystemContainer<type>::bitmap.at(entity_id) = false;
+        Map().erase(entity_id);
+        SystemContainer<C>::bitmap.at(entity_id) = false;
     }
 
-    template<Component C>
     typename SystemContainer<C>::container_type& Map() {
         return SystemContainer<C>::container;
     }
 
-    template<Component C>
     const BitMap<uint32_t>& Bitmap() {
         return SystemContainer<C>::bitmap;
     }

--- a/src/components/component.cpp
+++ b/src/components/component.cpp
@@ -10,27 +10,6 @@
 namespace trillek { namespace component {
 
 template<>
-struct ContainerRef<System> {
-    static System& container;
-};
-
-System& ContainerRef<System>::container = TrillekGame::GetSystemComponent();
-
-template<>
-struct ContainerRef<SystemValue> {
-    static SystemValue& container;
-};
-
-SystemValue& ContainerRef<SystemValue>::container = TrillekGame::GetSystemValueComponent();
-
-template<>
-struct ContainerRef<Shared> {
-    static Shared& container;
-};
-
-Shared& ContainerRef<Shared>::container = TrillekGame::GetSharedComponent();
-
-template<>
 std::shared_ptr<Container> Initialize<Component::VelocityMax>(const std::vector<Property> &properties) {
     glm::vec3 lmax(0.0f,0.0f,0.0f), amax(0.0f,0.0f,0.0f);
     id_t entity_id;
@@ -70,11 +49,11 @@ id_t Initialize<Component::ReferenceFrame>(bool& result, const std::vector<Prope
         std::string name = p.GetName();
         if (name == "entity") {
             reference_id = p.Get<id_t>();
-            if (! TrillekGame::GetSharedComponent().Has<Component::Velocity>(reference_id)) {
+            if (! Has<Component::Velocity>(reference_id)) {
                 LOGMSG(ERROR) << "ReferenceFrame: entity #" << reference_id << "does not have velocity";
                 return 0;
             }
-            ref_velocity = TrillekGame::GetSharedComponent().Get<Component::Velocity>(reference_id);
+            ref_velocity = Get<Component::Velocity>(reference_id);
             result = true;
         }
         else if (name == "entity_id") {
@@ -86,8 +65,8 @@ id_t Initialize<Component::ReferenceFrame>(bool& result, const std::vector<Prope
     }
     if (result) {
         // create IsReferenceFrame and CombinedVelocity components
-        TrillekGame::GetSystemValueComponent().Insert<Component::IsReferenceFrame>(reference_id, true);
-        TrillekGame::GetSystemComponent().Insert<Component::CombinedVelocity>(entity_id, ref_velocity);
+        Insert<Component::IsReferenceFrame>(reference_id, true);
+        Insert<Component::CombinedVelocity>(entity_id, ref_velocity);
         return reference_id;
     }
     return 0;

--- a/src/physics/collidable.cpp
+++ b/src/physics/collidable.cpp
@@ -1,7 +1,7 @@
 #include "physics/collidable.hpp"
 #include "transform.hpp"
 #include "trillek-game.hpp"
-#include "components/shared-component.hpp"
+#include "components/component.hpp"
 #include "systems/physics.hpp"
 #include "systems/resource-system.hpp"
 #include "resources/mesh.hpp"
@@ -73,7 +73,7 @@ bool Collidable::Initialize(const std::vector<Property> &properties) {
     }
 
     SetEntity(entity_id);
-    auto& entity_transform = TrillekGame::GetSharedComponent().Get<component::Component::GameTransform>(entity_id);
+    auto& entity_transform = component::Get<component::Component::GameTransform>(entity_id);
 
     if (shape == "capsule") {
         this->shape = std::move(std::unique_ptr<btCollisionShape>(new btCapsuleShape(this->radius, this->height)));
@@ -122,7 +122,7 @@ bool Collidable::Initialize(const std::vector<Property> &properties) {
 }
 
 void Collidable::SetEntity(unsigned int entity_id) {
-    auto& entity_transform = TrillekGame::GetSharedComponent().Get<component::Component::GameTransform>(entity_id);
+    auto& entity_transform = component::Get<component::Component::GameTransform>(entity_id);
     auto pos = entity_transform.GetTranslation();
     auto orientation = entity_transform.GetOrientation();
     this->motion_state = new btDefaultMotionState(btTransform(

--- a/src/systems/transform-system.cpp
+++ b/src/systems/transform-system.cpp
@@ -1,7 +1,6 @@
 #include "systems/transform-system.hpp"
 #include "transform.hpp"
 #include "trillek-game.hpp"
-#include "components/shared-component.hpp"
 #include "components/component.hpp"
 
 namespace trillek {
@@ -14,7 +13,7 @@ std::shared_ptr<TransformMap> TransformMap::instance = nullptr;
 bool TransformMap::Serialize(rapidjson::Document& document) {
     rapidjson::Value transform_node(rapidjson::kObjectType);
 
-    for (auto& entity_transform_wrapped : TrillekGame::GetSharedComponent().Map<Component::GameTransform>().Map()) {
+    for (auto& entity_transform_wrapped : GetRawContainer<Component::GameTransform>().Map().Map()) {
         auto& entity_transform = *Get<Component::GameTransform>(entity_transform_wrapped.second);
         rapidjson::Value transform_object(rapidjson::kObjectType);
 
@@ -140,7 +139,7 @@ bool TransformMap::Parse(rapidjson::Value& node) {
 
                     entity_transform.SetScale(glm::vec3(x, y, z));
                 }
-                TrillekGame::GetSharedComponent().Insert<Component::GameTransform>(entity_id, std::move(entity_transform));
+                Insert<Component::GameTransform>(entity_id, std::move(entity_transform));
             }
         }
 

--- a/src/trillek-scheduler.cpp
+++ b/src/trillek-scheduler.cpp
@@ -8,7 +8,9 @@
 
 #include "systems/system-base.hpp"
 #include "trillek-game.hpp"
+#if defined(_MSC_VER)
 #include "os.hpp"
+#endif
 #include "logging.hpp"
 
 namespace trillek {


### PR DESCRIPTION
A new component::GetRawContainer() enables to retrieve a component
container at run time.

The object returned must be upcast to its original type using
dynamic_cast().

Also simplify a lot the compoent adder class.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/trillek-team/trillek-common/2)

<!-- Reviewable:end -->
